### PR TITLE
Refactor WorkspaceService validation and rename configuration references

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,12 +7,30 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/) and foll
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Configuration YAML schema:** `spec.repositories` renamed to `spec.remotes` in configuration files (ADR 0010). Existing configuration YAML files must update the field name. Solution repos (`solution.json → spec.repositories`) are unchanged.
+
 ### Added
 
 - Self-SBOM generation in CI (`ci-build.yml` Job 3): `strata build sbom --scan .` runs against its own source tree, producing a CycloneDX 1.6 `sbom.json` artifact (dogfooding)
 - `sbom.json` artifact attached to every GitHub Release via `ci-release.yml`
 - `workflow_dispatch` trigger on `ci-docs.yml` for manual doc builds and testing
 - Edge image jobs now gate on SBOM job success (`needs: [build, docs, sbom]`)
+- ADR 0010: Decision record for renaming configuration repositories to remotes
+
+### Changed
+
+- `RepositoryModel` renamed to `RemoteModel` (backwards-compatible alias retained)
+- `RepositoryType` enum renamed to `RemoteType` (backwards-compatible alias retained)
+- `ConfigurationService.get_repositories()` → `get_remotes()`
+- `ConfigurationService.get_repo_map()` → `get_remote_map()`
+- `ConfigurationModel.get_repo_map()` → `get_remote_map()`
+- `SourceModel.repository` field description corrected to reference solution repos
+
+### Fixed
+
+- **Bug:** Workspace deep validation checked `configuration_model.spec.repositories` (manifest backends) instead of solution repos for provisioner `source.repository` references — repos registered via `strata repo add` now validate correctly
 
 ---
 

--- a/.strata/cli.yaml
+++ b/.strata/cli.yaml
@@ -1,3 +1,0 @@
-values:
-  last_execution_id: 8b0c0e44-e39a-493a-859f-c95c1527980d
-  last_execution_on: '2026-06-18T06:58:55.877827+00:00'

--- a/config/xyz-configuration/config/xyz-config.yaml
+++ b/config/xyz-configuration/config/xyz-config.yaml
@@ -34,7 +34,7 @@ spec:
       path: ".strata/deployments" # Base path (service appends /{deployment_name}/{version}/{timestamp}.json)
       # Uncomment below for gitops storage:
       # type: gitops
-      # repository: "state-repo"      # Reference to a repository entry from spec.repositories
+      # repository: "state-repo"      # Reference to a remote entry from spec.remotes
       # branch: "manifests"           # Target branch for manifest commits
       # tag: true                      # Create git tag {deployment_name}/{version} (default: true)
       # path: "deployments"            # Base path within the repo
@@ -52,8 +52,8 @@ spec:
         - de-fra
         - at-vie
 
-  # Required repositories for this configuration (bundled with platform)
-  repositories:
+  # Required remotes for this configuration (bundled with platform)
+  remotes:
     - name: xyz_configuration
       type: bundled
       repository: .

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -211,7 +211,7 @@ spec:
   deployment:
     manifest:
       type: gitops
-      repository: state-repo          # must match a name in spec.repositories
+      repository: state-repo          # must match a name in spec.remotes
       branch: manifests
       path: deployments
       tag: true                       # create git tag {deployment}/{version} after write

--- a/docs/config/manifest.md
+++ b/docs/config/manifest.md
@@ -72,7 +72,7 @@ Commit manifests automatically to a Git repository (state repo pattern):
 manifest:
   type: gitops
   path: "deployments"                           # Directory in target repo
-  repository: xyz-state-repo                    # Repo name (must be in spec.repositories)
+  repository: xyz-state-repo                    # Remote name (must be in spec.remotes)
   branch: manifests                             # Target branch
   tag: true                                     # Create git tag after commit
 ```
@@ -106,11 +106,11 @@ git push origin <branch_name> --tags
 
 **Repository requirement:**
 
-The `repository` field must reference a registered repository in `spec.repositories`:
+The `repository` field must reference a registered remote in `spec.remotes`:
 
 ```yaml
 spec:
-  repositories:
+  remotes:
     - name: xyz-state-repo
       url: git@github.com:org/xyz-state-repo.git
       branch: main
@@ -207,12 +207,12 @@ strata deploy run -f deployments/prod.yaml
 
 ## Troubleshooting
 
-| Issue                        | Cause                                | Solution                                                        |
-| ---------------------------- | ------------------------------------ | --------------------------------------------------------------- |
-| Manifest not written         | `manifest` section missing in config | Add `manifest` section with `type` and `path`                   |
-| gitops type fails to push    | Repository not registered            | Verify `repository` field matches a name in `spec.repositories` |
-| gitops fails: branch not set | Required field missing               | Add `branch` field when `type: gitops`                          |
-| Manifest has empty `content` | Platform artifact not generated      | Run `strata build run` before `strata deploy run`               |
+| Issue                        | Cause                                | Solution                                                   |
+| ---------------------------- | ------------------------------------ | ---------------------------------------------------------- |
+| Manifest not written         | `manifest` section missing in config | Add `manifest` section with `type` and `path`              |
+| gitops type fails to push    | Remote not registered                | Verify `repository` field matches a name in `spec.remotes` |
+| gitops fails: branch not set | Required field missing               | Add `branch` field when `type: gitops`                     |
+| Manifest has empty `content` | Platform artifact not generated      | Run `strata build run` before `strata deploy run`          |
 
 ---
 

--- a/docs/decisions/0010-rename-configuration-repositories-to-remotes.md
+++ b/docs/decisions/0010-rename-configuration-repositories-to-remotes.md
@@ -1,0 +1,153 @@
+# Rename configuration spec.repositories to spec.remotes
+
+- Status: proposed
+- Date: 2026-06-18
+- Issue: repo validation bug (provisioner source.repository checked against wrong set)
+
+## Context and Problem Statement
+
+Strata has two separate collections both named "repositories":
+
+1. **`solution.json → spec.repositories`** — managed by `strata repo add`. Maps named
+   source code repos to local filesystem paths. Enables `@repo/path` resolution so
+   developers can work with multiple IaC/CaC/Cfg repos simultaneously, each at
+   different local locations.
+
+2. **`configuration.yaml → spec.repositories`** — hand-edited in team-shared config.
+   A registry of named remote endpoints (git URLs, container registries, bundled paths)
+   that the platform pulls from or pushes artifacts to.
+
+The naming collision caused a validated bug: `workspace_service._validate_dynamic()`
+checked provisioner `source.repository` references (which target solution repos) against
+`configuration_model.spec.repositories` (which lists artifact backends). A repo properly
+registered via `strata repo add` failed validation because the validator looked in the
+wrong collection.
+
+Beyond the bug, the shared name confuses contributors. The two concepts have different:
+
+- **Ownership:** developer-local state vs team-shared configuration
+- **Direction:** "where is my source code?" vs "where do artifacts come from / go to?"
+- **Path semantics:** absolute filesystem paths vs relative deploy paths or remote URLs
+- **Lifecycle:** `strata repo add` at dev setup vs defined once in config and committed
+
+## Decision Drivers
+
+- Pre-v1 — breaking YAML schema changes are still acceptable
+- The naming collision already caused a production bug
+- Contributors and AI agents repeatedly confuse the two concepts
+- Solution repos cannot be merged into configuration repos (multiple repos bring
+  multiple configs; solution repos are developer-local state)
+- Configuration repos cannot be merged into solution repos (they define team-shared
+  remote endpoints, not local checkouts)
+
+## Considered Options
+
+### Option A — Rename configuration field to `spec.remotes`
+
+Rename the configuration-side collection:
+
+- `ConfigurationSpecModel.repositories` → `ConfigurationSpecModel.remotes`
+- `RepositoryModel` class → `RemoteModel`
+- `RepositoryType` enum → `RemoteType`
+- `ConfigurationService.get_repositories()` → `get_remotes()`
+- `ConfigurationModel.get_repo_map()` → `get_remote_map()`
+- YAML field: `spec.repositories:` → `spec.remotes:`
+- Solution repos stay as `repositories` (they ARE repos)
+
+**Pro:** "Remote" is git-familiar, naturally bidirectional (fetch from, push to),
+covers all three current types:
+- `type: bundled` → a local remote (like `git remote add local .`)
+- `type: gitops` → a git remote for manifest push/pull
+- `type: container` → a container registry remote
+
+**Pro:** Minimal conceptual distance — developers already think "remote = named URL."
+
+**Pro:** Clear disambiguation — `repositories` = source code checkouts,
+`remotes` = named endpoints.
+
+### Option B — Rename to `spec.stores`
+
+**Pro:** Emphasises storage/artifact nature.
+**Con:** `ManifestStoreType` enum already uses "store" — risks confusion between
+the store type and the store entry. Doesn't convey "pull from" semantics well.
+
+### Option C — Rename to `spec.origins`
+
+**Pro:** Git-familiar ("where it came from").
+**Con:** Implies read-only source; config repos are also push targets (manifest gitops).
+Doesn't capture bidirectional nature.
+
+### Option D — Rename to `spec.catalogs`
+
+**Pro:** "Known named sources" — good for discovery/lookup.
+**Con:** Implies read-only browsing; doesn't convey "push manifests here."
+
+### Option E — Rename to `spec.backends`
+
+**Pro:** Accurate for storage backends.
+**Con:** Too Terraform-specific in connotation. Confusing for non-IaC users.
+
+### Option F — Rename to `spec.endpoints`
+
+**Pro:** Generic network endpoint concept.
+**Con:** Better reserved for future API/service endpoint extensions.
+
+### Option G — Keep both as `repositories` (status quo + fix descriptions only)
+
+Fix the `SourceModel.repository` field description and validator bug. No schema change.
+
+**Pro:** Zero breaking changes.
+**Con:** Naming collision persists. Future contributors will hit the same confusion.
+The bug proved this isn't theoretical.
+
+## Decision Outcome
+
+**Chosen option: A — Rename to `spec.remotes`**
+
+The term "remote" is universally understood from git workflows, naturally covers all
+three endpoint types (local, git, container), is bidirectional (fetch and push), and
+creates a clean semantic boundary:
+
+- `solution.spec.repositories` = "repos I have checked out locally"
+- `configuration.spec.remotes` = "named endpoints the platform talks to"
+
+## Scope of Change
+
+| Category      | Files         | Key changes                                                                                   |
+| ------------- | ------------- | --------------------------------------------------------------------------------------------- |
+| Models        | 2             | `RepositoryModel` → `RemoteModel`; `RepositoryType` → `RemoteType`; field rename              |
+| Services      | 1             | Method renames: `get_repositories()` → `get_remotes()`, `get_repo_map()` → `get_remote_map()` |
+| Controllers   | 1             | `repository_controller.py` — all method names and internal variables                          |
+| Builders      | 1             | Docstring updates (SBOM deps collector)                                                       |
+| Templates     | 4             | YAML section headers: `repositories:` → `remotes:`                                            |
+| Test data     | 1             | Configuration YAML fixtures                                                                   |
+| Tests         | ~2            | Service method call updates                                                                   |
+| Documentation | 3             | Spec references and examples                                                                  |
+| **Total**     | **~14 files** |                                                                                               |
+
+## What Does NOT Change
+
+- `solution.json → spec.repositories` — stays as-is
+- `SolutionSpecRepositoryModel` — stays as-is
+- `SolutionController.get_repositories()` — stays as-is
+- `strata repo add/remove/list/status` CLI — stays as-is
+- `SourceModel.repository` field name — stays (but description is corrected to
+  reference "solution registered repositories" not "configuration repositories")
+
+## Consequences
+
+**Positive:**
+- Eliminates naming collision that caused the validation bug
+- Clear mental model for contributors: repos = local, remotes = endpoints
+- Aligns with git vocabulary that developers already know
+- Pre-v1 change avoids breaking users after stable release
+
+**Negative:**
+- Breaking YAML schema change for existing configuration files
+- All existing `configuration.yaml` files must update `repositories:` → `remotes:`
+- ~14 files touched in a single refactoring PR
+
+**Mitigation:**
+- Provide a one-time migration note in CHANGELOG
+- Consider temporary backwards-compat alias during transition (accept both field names
+  with a deprecation warning) — optional, may not be needed pre-v1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,6 +81,7 @@ strata
    decisions/0007-deployment-state-locking
    decisions/0008-infrastructure-drift-detection
    decisions/0009-sbom-extended-sources-and-inventory
+   decisions/0010-rename-configuration-repositories-to-remotes
 
 .. toctree::
    :maxdepth: 2

--- a/docs/platform/models.md
+++ b/docs/platform/models.md
@@ -47,7 +47,7 @@ Never use plain `str` for `name` fields — always use `PlatformName` from `comm
 | `platform-artifact`   | `PlatformArtifactModel`   | Build output written to `.strata/build/`                          |
 | `workspace-template`  | `PlatformTemplateModel`   | Scaffold for `strata sln init --from-template`                    |
 | `solution`            | `SolutionModel`           | Solution registry (`solution.json`)                               |
-| `repository`          | `RepositoryModel`         | Registered repository entry                                       |
+| `remote`              | `RemoteModel`             | Named remote endpoint (artifact source/target)                    |
 | `integration`         | `IntegrationModel`        | Integration backend credential config                             |
 
 ## Two-Phase Validation

--- a/src/strata/controllers/repository_controller.py
+++ b/src/strata/controllers/repository_controller.py
@@ -1,4 +1,4 @@
-"""Controller for managing and fetching configuration repositories."""
+"""Controller for managing and fetching configuration remotes."""
 
 import shutil
 from pathlib import Path
@@ -8,17 +8,17 @@ from strata.controllers.base_controller import BaseController
 from strata.integrations.factory import IntegrationFactory
 from strata.integrations.git import GitIntegration
 from strata.models.integration_model import IntegrationModel
-from strata.models.repository_model import RepositoryModel, RepositoryType
+from strata.models.repository_model import RemoteModel, RemoteType
 from strata.models.solution_model import SolutionSpecRepositoryModel
 from strata.services.configuration_service import ConfigurationService
 
 
 class RepositoryController(BaseController):
     """
-    Controls repository operations for configuration management.
+    Controls remote operations for configuration management.
 
-    Orchestrates fetching repositories from various sources (gitops, bundled,
-    container) into the workspace directory based on configuration.spec.repositories.
+    Orchestrates fetching remotes from various sources (gitops, bundled,
+    container) into the workspace directory based on configuration.spec.remotes.
 
     Source routing:
     - GITOPS  : clone via GitIntegration (or pull if already on disk)
@@ -47,13 +47,13 @@ class RepositoryController(BaseController):
         progress_callback: Optional[Callable[[str, int, int], None]] = None,
     ) -> Tuple[bool, List[str]]:
         """
-        Fetch all repositories defined in configuration.
+        Fetch all remotes defined in configuration.
 
         Args:
             work_path: Working directory for resolving bundled paths
-            force: If True, re-fetch even if repository already exists on disk
-            progress_callback: Optional callback(repo_name, current, total)
-                called before each repository fetch
+            force: If True, re-fetch even if remote already exists on disk
+            progress_callback: Optional callback(remote_name, current, total)
+                called before each remote fetch
 
         Returns:
             Tuple of (success, list of error messages)
@@ -73,9 +73,9 @@ class RepositoryController(BaseController):
             self._errors.append(error_msg)
             return False, self._errors.copy()
 
-        repositories = self._config_service.model.spec.repositories
+        repositories = self._config_service.model.spec.remotes
         if not repositories:
-            self.logger.info("No repositories configured")
+            self.logger.info("No remotes configured")
             return True, []
 
         total = len(repositories)
@@ -129,13 +129,13 @@ class RepositoryController(BaseController):
 
     def get_repository_status(self, work_path: str) -> Dict[str, Dict[str, Any]]:
         """
-        Get status of all configured repositories.
+        Get status of all configured remotes.
 
         Args:
-            work_path: Workspace root directory where repositories are materialized
+            work_path: Workspace root directory where remotes are materialized
 
         Returns:
-            Dict of repository name to status info
+            Dict of remote name to status info
         """
         if not self._config_service.model:
             self.logger.warning("No configuration loaded")
@@ -145,41 +145,41 @@ class RepositoryController(BaseController):
             self.logger.warning("Configuration spec not found")
             return {}
 
-        repositories = self._config_service.model.spec.repositories
-        if not repositories:
+        remotes = self._config_service.model.spec.remotes
+        if not remotes:
             return {}
 
         status: Dict[str, Dict[str, Any]] = {}
 
-        for repo in repositories:
-            target_path = self._resolve_target_path(work_path=work_path, source=repo)
-            repo_name = repo.name or repo.repository
+        for remote in remotes:
+            target_path = self._resolve_target_path(work_path=work_path, source=remote)
+            remote_name = remote.name or remote.repository
 
-            status[repo_name] = {
-                "name": repo.name or "unnamed",
-                "type": repo.type.value,
-                "repository": repo.repository,
-                "reference": repo.reference,
-                "source_path": repo.source_path,
-                "deploy_path": repo.deploy_path,
+            status[remote_name] = {
+                "name": remote.name or "unnamed",
+                "type": remote.type.value,
+                "repository": remote.repository,
+                "reference": remote.reference,
+                "source_path": remote.source_path,
+                "deploy_path": remote.deploy_path,
                 "target_path": str(target_path),
                 "exists": target_path.exists(),
                 "is_git": ((target_path / ".git").exists() if target_path.exists() else False),
             }
 
         self.logger.debug(
-            "Repository status retrieved",
-            repository_count=len(status),
+            "Remote status retrieved",
+            remote_count=len(status),
         )
 
         return status
 
     def count_repositories(self) -> int:
         """
-        Count total repositories in configuration.
+        Count total remotes in configuration.
 
         Returns:
-            Number of repositories configured
+            Number of remotes configured
         """
         if not self._config_service.model:
             return 0
@@ -187,15 +187,15 @@ class RepositoryController(BaseController):
         if not self._config_service.model.spec:
             return 0
 
-        repositories = self._config_service.model.spec.repositories
-        return len(repositories) if repositories else 0
+        remotes = self._config_service.model.spec.remotes
+        return len(remotes) if remotes else 0
 
     def validate_repositories(self, work_path: str) -> Tuple[bool, List[str]]:
         """
-        Validate that all repositories exist on disk.
+        Validate that all remotes exist on disk.
 
         Args:
-            work_path: Workspace root directory where repositories are materialized
+            work_path: Workspace root directory where remotes are materialized
 
         Returns:
             Tuple of (all_exist, list of missing repository names)
@@ -295,36 +295,36 @@ class RepositoryController(BaseController):
     def _fetch_single_repository(
         self,
         work_path: str,
-        source: RepositoryModel,
+        source: RemoteModel,
         force: bool,
     ) -> bool:
-        """Fetch a single repository based on its type."""
+        """Fetch a single remote based on its type."""
         target_path = self._resolve_target_path(work_path=work_path, source=source)
         repo_name = source.name or source.repository
 
         self.logger.debug(
-            "Fetching repository",
-            repository=repo_name,
+            "Fetching remote",
+            remote=repo_name,
             type=source.type.value,
             target_path=str(target_path),
             force=force,
         )
 
-        if source.type == RepositoryType.GITOPS:
+        if source.type == RemoteType.GITOPS:
             return self._fetch_gitops(source=source, target_path=target_path, force=force)
 
-        if source.type == RepositoryType.BUNDLED:
+        if source.type == RemoteType.BUNDLED:
             return self._fetch_bundled(work_path=work_path, source=source, target_path=target_path, force=force)
 
-        if source.type == RepositoryType.CONTAINER:
-            self.logger.warning("Container repository type not supported", repository=repo_name)
+        if source.type == RemoteType.CONTAINER:
+            self.logger.warning("Container remote type not supported", remote=repo_name)
             return True
 
-        self.logger.error("Unknown repository type", repository=repo_name, type=source.type)
+        self.logger.error("Unknown remote type", remote=repo_name, type=source.type)
         return False
 
-    def _resolve_target_path(self, work_path: str, source: RepositoryModel) -> Path:
-        """Resolve repository target directory under workspace root."""
+    def _resolve_target_path(self, work_path: str, source: RemoteModel) -> Path:
+        """Resolve remote target directory under workspace root."""
         target_name = source.deploy_path or source.name or source.repository
         return Path(work_path) / target_name
 
@@ -438,11 +438,11 @@ class RepositoryController(BaseController):
 
     def _fetch_gitops(
         self,
-        source: RepositoryModel,
+        source: RemoteModel,
         target_path: Path,
         force: bool,
     ) -> bool:
-        """Clone or pull a GitOps repository via GitIntegration."""
+        """Clone or pull a GitOps remote via GitIntegration."""
         repo_name = source.name or source.repository
 
         git = self._get_git_integration()
@@ -482,16 +482,16 @@ class RepositoryController(BaseController):
     def _fetch_bundled(
         self,
         work_path: str,
-        source: RepositoryModel,
+        source: RemoteModel,
         target_path: Path,
         force: bool,
     ) -> bool:
         """
-        Copy a bundled (local) repository to the workspace directory.
+        Copy a bundled (local) remote to the workspace directory.
 
         Args:
             work_path: Working directory used to resolve the relative source path
-            source: RepositoryModel for the repository
+            source: RemoteModel for the remote
             target_path: Resolved target directory
             force: Overwrite target if it already exists
 

--- a/src/strata/models/common_models.py
+++ b/src/strata/models/common_models.py
@@ -205,7 +205,7 @@ class SourceModel(PlatformBaseModel):
     """
 
     repository: Optional[PlatformName] = Field(
-        None, description="Name of the repository from configuration's repositories list"
+        None, description="Name of the repository from solution registered repositories (via strata repo add)"
     )
     source_path: Optional[Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]] = Field(
         None,

--- a/src/strata/models/configuration_model.py
+++ b/src/strata/models/configuration_model.py
@@ -15,7 +15,7 @@ from strata.models.common_models import (
 )
 from strata.models.integration_model import IntegrationModel
 from strata.models.policy_model import PolicyModel
-from strata.models.repository_model import RepositoryModel
+from strata.models.repository_model import RemoteModel
 
 
 class ConfigurationSecurityModel(PlatformBaseModel):
@@ -256,7 +256,7 @@ class ConfigurationManifestModel(PlatformBaseModel):
     )
     repository: Optional[str] = Field(
         None,
-        description="Repository name from spec.repositories (required when type=gitops)",
+        description="Remote name from spec.remotes (required when type=gitops)",
     )
     branch: Optional[str] = Field(
         None,
@@ -407,8 +407,8 @@ class ConfigurationSpecModel(PlatformBaseModel):
         default_factory=list,
         description="External integrations that extend platform capabilities",
     )
-    repositories: Optional[List[RepositoryModel]] = Field(
-        None, description="Deployment manifest repositories (artifact storage backends)"
+    remotes: Optional[List[RemoteModel]] = Field(
+        None, description="Named remote endpoints (artifact sources and deployment targets)"
     )
     lifecycle: Optional[CommonLifecycleModel] = Field(None, description="Configuration lifecycle phases")
     configuration: Optional[Dict[str, Any]] = Field(None, description="List of configuration defaults")
@@ -528,9 +528,9 @@ class ConfigurationModel(PlatformBaseModel):
     meta: ConfigurationMetaModel = Field(..., description="Metadata for the configuration model.")
     spec: ConfigurationSpecModel = Field(..., description="Specification for the configuration.")
 
-    def get_repo_map(self) -> Dict[str, str]:
-        """Return a ``{repo_name: deploy_path}`` mapping for resolving ``@repo_name/...`` references."""
-        repos = self.spec.repositories if self.spec and self.spec.repositories else {}
-        if not repos or len(repos) == 0:
+    def get_remote_map(self) -> Dict[str, str]:
+        """Return a ``{remote_name: deploy_path}`` mapping for resolving ``@remote_name/...`` references."""
+        remotes = self.spec.remotes if self.spec and self.spec.remotes else {}
+        if not remotes or len(remotes) == 0:
             return {}
-        return {repo.name: repo.deploy_path for repo in repos if repo.name and repo.deploy_path}
+        return {remote.name: remote.deploy_path for remote in remotes if remote.name and remote.deploy_path}

--- a/src/strata/models/repository_model.py
+++ b/src/strata/models/repository_model.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Pydantic model for deployment source (repository) configuration validation."""
+"""Pydantic model for remote source configuration validation."""
 
 import re
 from enum import Enum
@@ -16,9 +16,9 @@ from pydantic import (
 from strata.models.common_models import PlatformBaseModel, PlatformName
 
 
-class RepositoryType(str, Enum):
+class RemoteType(str, Enum):
     """
-    Enumeration of supported deployment source types.
+    Enumeration of supported remote source types.
 
     BUNDLED: Platform-bundled modules (available within the platform)
     GITOPS: GitOps repository to clone from
@@ -30,12 +30,12 @@ class RepositoryType(str, Enum):
     CONTAINER = "container"
 
 
-# Model for deployment configuration.
-class RepositoryModel(PlatformBaseModel):
+# Model for remote configuration.
+class RemoteModel(PlatformBaseModel):
     """
-    Model for deployment source configuration.
+    Model for remote source configuration.
 
-    Supports two source types:
+    Supports three remote types:
 
     BUNDLED:
         - Platform-bundled modules available within the platform itself
@@ -59,9 +59,11 @@ class RepositoryModel(PlatformBaseModel):
         - deploy_path: Optional path to deployment artifacts
     """
 
-    name: Optional[PlatformName] = Field(None, description="Optional name for the source configuration")
-    description: Optional[str] = Field(None, description="Human-readable description of this repository")
-    type: RepositoryType = Field(description="Source type: bundled (platform-bundled) or gitops (Git repository)")
+    name: Optional[PlatformName] = Field(None, description="Optional name for the remote")
+    description: Optional[str] = Field(None, description="Human-readable description of this remote")
+    type: RemoteType = Field(
+        description="Remote type: bundled (platform-bundled), gitops (Git repository), or container"
+    )
     repository: Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)] = Field(
         description="Source repository or image for the deployment"
     )
@@ -134,15 +136,15 @@ class RepositoryModel(PlatformBaseModel):
         """
         deployment_type = info.data.get("type")
 
-        if deployment_type == RepositoryType.BUNDLED:
+        if deployment_type == RemoteType.BUNDLED:
             # Bundled: validate format (paths can be created later)
             if v not in [".", "/"] and not re.match(r"^[a-zA-Z0-9.\-_/\\: ]+$", v):
                 raise ValueError(f"Bundled repository path format is invalid: {v}")
-        elif deployment_type == RepositoryType.GITOPS:
+        elif deployment_type == RemoteType.GITOPS:
             # Git URL: must look like a valid git URL
             if not re.match(r"^(https?://|git@|ssh://)", v):
                 raise ValueError(f"GitOps repository must be a valid Git URL: {v}")
-        elif deployment_type == RepositoryType.CONTAINER:
+        elif deployment_type == RemoteType.CONTAINER:
             # Container: validate registry/image format
             # Examples: docker.io/library/nginx, ghcr.io/org/image, myregistry.azurecr.io/namespace/image
             if not re.match(r"^[a-zA-Z0-9.\-_:/]+$", v):
@@ -158,14 +160,14 @@ class RepositoryModel(PlatformBaseModel):
         """
         deployment_type = info.data.get("type")
 
-        if deployment_type == RepositoryType.BUNDLED:
+        if deployment_type == RemoteType.BUNDLED:
             # Bundled: can be '.' or '/' or a version string
             pass  # Allow any value for bundled references
-        elif deployment_type == RepositoryType.GITOPS:
+        elif deployment_type == RemoteType.GITOPS:
             # Git: must be a valid branch/tag/commit
             if not re.match(r"^[a-zA-Z0-9.\-_/]+$", v):
                 raise ValueError(f"Git reference must be a valid branch, tag, or commit hash: {v}")
-        elif deployment_type == RepositoryType.CONTAINER:
+        elif deployment_type == RemoteType.CONTAINER:
             # Container: can be tag (v1.0.0, latest) or digest (sha256:abc123...)
             # Allow alphanumeric, dots, dashes, underscores, and sha256: prefix
             if not re.match(r"^(sha256:[a-f0-9]{64}|[a-zA-Z0-9.\-_]+)$", v):
@@ -198,17 +200,17 @@ class RepositoryModel(PlatformBaseModel):
         return cls._validate_relative_path(v, "deploy_path")
 
     @model_validator(mode="after")
-    def validate_type_specific_requirements(self) -> "RepositoryModel":
+    def validate_type_specific_requirements(self) -> "RemoteModel":
         """
         Cross-field validation for type-specific field requirements.
         """
         # BUNDLED and GITOPS require source_path
-        if self.type in [RepositoryType.BUNDLED, RepositoryType.GITOPS]:
+        if self.type in [RemoteType.BUNDLED, RemoteType.GITOPS]:
             if not self.source_path:
                 raise ValueError(f"source_path is required for {self.type.value} source type")
 
         # CONTAINER type should not use source_path
-        if self.type == RepositoryType.CONTAINER:
+        if self.type == RemoteType.CONTAINER:
             if self.source_path is not None:
                 raise ValueError(
                     "source_path is not applicable for container source type. Container images are self-contained."
@@ -217,9 +219,14 @@ class RepositoryModel(PlatformBaseModel):
         return self
 
     def get_label(self) -> str:  # Not Optional
-        """Get the label/name of the source configuration."""
+        """Get the label/name of the remote configuration."""
         if self.name and self.type:
             return f"{self.name} ({self.type.value})"
         elif self.type:
             return str(self.type.value)
-        return "Unnamed Source"
+        return "Unnamed Remote"
+
+
+# Backwards-compatible aliases (deprecated — will be removed before v1)
+RepositoryModel = RemoteModel
+RepositoryType = RemoteType

--- a/src/strata/services/configuration_service.py
+++ b/src/strata/services/configuration_service.py
@@ -171,7 +171,7 @@ class ConfigurationService(BaseService["ConfigurationModel"]):
 
         # Validate logging file reference exists on disk
         if work_path and self.model.spec.logging and self.model.spec.logging.file:
-            repo_map = self.get_repo_map()
+            repo_map = self.get_remote_map()
             errors.extend(
                 self._validate_file_refs(
                     work_path,

--- a/src/strata/services/configuration_service.py
+++ b/src/strata/services/configuration_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from strata.exceptions import PlatformFileNotFoundError
 from strata.logger import get_logger
 from strata.models.configuration_model import ConfigurationModel
-from strata.models.repository_model import RepositoryModel
+from strata.models.repository_model import RemoteModel
 from strata.services.base_service import BaseService
 from strata.utils import config
 from strata.utils.configuration_loader import ConfigurationLoader
@@ -339,19 +339,19 @@ class ConfigurationService(BaseService["ConfigurationModel"]):
         self._ensure_validated()
         return self.model if self.model else None
 
-    def get_repositories(self) -> Optional[List[RepositoryModel]]:
-        """Get the list of repositories from the configuration."""
+    def get_remotes(self) -> Optional[List[RemoteModel]]:
+        """Get the list of remotes from the configuration."""
         self._ensure_validated()
-        if self.model and self.model.spec and self.model.spec.repositories:
-            return self.model.spec.repositories
+        if self.model and self.model.spec and self.model.spec.remotes:
+            return self.model.spec.remotes
         return None
 
-    def get_repo_map(self) -> Dict[str, str]:
-        """Return a ``{repo_name: deploy_path}`` mapping for resolving ``@repo_name/...`` references."""
-        repos = self.get_repositories()
-        if not repos:
+    def get_remote_map(self) -> Dict[str, str]:
+        """Return a ``{remote_name: deploy_path}`` mapping for resolving ``@remote_name/...`` references."""
+        remotes = self.get_remotes()
+        if not remotes:
             return {}
-        return {repo.name: repo.deploy_path for repo in repos if repo.name and repo.deploy_path}
+        return {remote.name: remote.deploy_path for remote in remotes if remote.name and remote.deploy_path}
 
     # Environment variable APIs
 

--- a/src/strata/services/customer_service.py
+++ b/src/strata/services/customer_service.py
@@ -69,7 +69,7 @@ class CustomerService(BaseService["CustomerModel"]):
 
         # Validate environment file paths exist on disk
         if work_path and self.model.spec.environments:
-            config_repo_map = configuration_model.get_repo_map() if configuration_model else {}
+            config_repo_map = configuration_model.get_remote_map() if configuration_model else {}
             repo_map = {**config_repo_map, **(self._repo_map or {})}
             file_refs = [(f"Environment[{i}]", env_path) for i, env_path in enumerate(self.model.spec.environments)]
             errors.extend(self._validate_file_refs(work_path, repo_map, file_refs))

--- a/src/strata/services/deployment_service.py
+++ b/src/strata/services/deployment_service.py
@@ -83,7 +83,7 @@ class DeploymentService(BaseService["DeploymentModel"]):
             # Merge solution-level repo_map (self._repo_map) with config-level repo_map.
             # Solution names (e.g. 'haven') take precedence for resolving @repo/... refs
             # in deployment files, which use solution repo names, not config repo names.
-            config_repo_map = configuration_model.get_repo_map() if configuration_model else {}
+            config_repo_map = configuration_model.get_remote_map() if configuration_model else {}
             repo_map = {**config_repo_map, **(self._repo_map or {})}
             file_refs = []
             for i, env_path in enumerate(self.model.spec.environments or []):
@@ -608,7 +608,7 @@ class DeploymentService(BaseService["DeploymentModel"]):
         # Build repo_map once for all @repo_name/... path resolutions in this call.
         # Merge solution-level map (caller-supplied) with config-service map.
         # Solution names take precedence so @haven/... refs resolve correctly.
-        config_repo_map: Dict[str, str] = ConfigurationService.get_instance().get_repo_map()
+        config_repo_map: Dict[str, str] = ConfigurationService.get_instance().get_remote_map()
         repo_map = {**config_repo_map, **(repo_map or {})}
 
         try:

--- a/src/strata/services/namespace_service.py
+++ b/src/strata/services/namespace_service.py
@@ -42,7 +42,7 @@ class NamespaceService(BaseService["NamespaceModel"]):
             return True, []
 
         file_refs = []
-        config_repo_map = configuration_model.get_repo_map() if configuration_model else {}
+        config_repo_map = configuration_model.get_remote_map() if configuration_model else {}
         repo_map = {**config_repo_map, **(self._repo_map or {})}
 
         if self.model and self.model.spec.modules:

--- a/src/strata/services/workspace_service.py
+++ b/src/strata/services/workspace_service.py
@@ -63,9 +63,9 @@ class WorkspaceService(BaseService["WorkspaceModel"]):
         Phase 2: Dynamic validation against configuration.
 
         Validates:
-        1. Provisioner repository references (workspace.spec.provisioners -> configuration.spec.repositories)
+        1. Provisioner repository references (workspace.spec.provisioners -> solution registered repos)
         2. Provisioner validity (validated via ProvisionerType enum)
-        3. Module repository references (loaded modules -> configuration.spec.repositories)
+        3. Module repository references (loaded modules -> solution registered repos)
         4. Topology provider references (workspace.spec.providers)
         5. Topology provisioner references (workspace.spec.provisioners)
         6. Component roles against configuration topology definitions
@@ -90,16 +90,16 @@ class WorkspaceService(BaseService["WorkspaceModel"]):
         # Get workspace provisioner names (topology references provisioners by name)
         workspace_provisioner_names = {p.name for p in self.model.spec.provisioners}
 
-        # Build repository map from configuration
-        config_repository_names = set()
-        if configuration_model.spec.repositories:
-            config_repository_names = {repo.name for repo in configuration_model.spec.repositories}
+        # Build solution repository names from the repo map registered via `strata repo add`
+        # (stored in solution.json, set on self._repo_map before _validate_dynamic is called).
+        # Note: configuration_model.spec.repositories is for gitops manifest backends — a different concept.
+        solution_repository_names: Set[str] = set(self._repo_map.keys()) if self._repo_map else set()
 
         # STEP 1: Validate provisioner repository references
-        # Check that each provisioner's source.repository exists in configuration
+        # Check that each provisioner's source.repository exists in the solution's registered repos
         for provisioner in self.model.spec.provisioners:
             if provisioner.source and provisioner.source.repository:
-                if provisioner.source.repository not in config_repository_names:
+                if provisioner.source.repository not in solution_repository_names:
                     error = InvalidReferenceError(
                         source_type="Provisioner",
                         source_name=provisioner.name,
@@ -133,7 +133,7 @@ class WorkspaceService(BaseService["WorkspaceModel"]):
                     and module_service.model.spec.source
                 ):
                     module_repo = module_service.model.spec.source.repository
-                    if module_repo not in config_repository_names:
+                    if module_repo not in solution_repository_names:
                         error = InvalidReferenceError(
                             source_type="Module",
                             source_name=module_name,

--- a/src/strata/services/workspace_service.py
+++ b/src/strata/services/workspace_service.py
@@ -238,7 +238,7 @@ class WorkspaceService(BaseService["WorkspaceModel"]):
 
         # STEP 5: Validate that all file: references resolve to existing files on disk
         if work_path:
-            config_repo_map = configuration_model.get_repo_map() if configuration_model else {}
+            config_repo_map = configuration_model.get_remote_map() if configuration_model else {}
             repo_map = {**config_repo_map, **(self._repo_map or {})}
             file_refs = []
             for p in self.model.spec.providers:
@@ -471,7 +471,7 @@ class WorkspaceService(BaseService["WorkspaceModel"]):
         # Build repo_map once for all @repo_name/... path resolutions in this call.
         # Merge solution-level map (caller-supplied) with config-service map.
         # Solution names take precedence so @haven/... refs resolve correctly.
-        config_repo_map: Dict[str, str] = ConfigurationService.get_instance().get_repo_map()
+        config_repo_map: Dict[str, str] = ConfigurationService.get_instance().get_remote_map()
         repo_map = {**config_repo_map, **(repo_map or {})}
 
         # Load firewall services from workspace spec firewalls

--- a/src/strata/templates/examples/aks/scaffold/config/${solution_name}-config.yaml
+++ b/src/strata/templates/examples/aks/scaffold/config/${solution_name}-config.yaml
@@ -23,8 +23,8 @@ spec:
         required: true
         description: "Target environment"
 
-  # Repositories available via @${solution_name}/... references
-  repositories:
+  # Remotes available via @${solution_name}/... references
+  remotes:
     - name: ${solution_name}
       type: gitops
       repository: git@github.com:your-org/${solution_name}-config.git

--- a/src/strata/templates/examples/compose/scaffold/config/${solution_name}-config.yaml
+++ b/src/strata/templates/examples/compose/scaffold/config/${solution_name}-config.yaml
@@ -23,8 +23,8 @@ spec:
         required: true
         description: "Target environment"
 
-  # Repositories available via @${solution_name}/... references
-  repositories:
+  # Remotes available via @${solution_name}/... references
+  remotes:
     - name: ${solution_name}
       type: gitops
       repository: git@github.com:your-org/${solution_name}-config.git

--- a/src/strata/templates/solution/dot.strata/templates/module.yaml
+++ b/src/strata/templates/solution/dot.strata/templates/module.yaml
@@ -13,11 +13,11 @@ meta:
   labels:
     version: ${version}
     category: "application"
-  tags: [ "template", "module" ]
+  tags: ["template", "module"]
 spec:
   # Module source
   source:
-    repository: main_repo # Repository name from configuration.spec.repositories
+    repository: main_repo # Remote name from solution registered repositories
     source_path: "services/app" # Path within repository
     target_path: "services/app" # Target deployment path
 

--- a/src/strata/templates/solution/dot.strata/templates/workspace.yaml
+++ b/src/strata/templates/solution/dot.strata/templates/workspace.yaml
@@ -12,7 +12,7 @@ meta:
     owner: ${owner}
   labels:
     version: ${version}
-  tags: [ "template", "workspace" ]
+  tags: ["template", "workspace"]
 spec:
   # Providers (cloud/infrastructure providers)
   providers:
@@ -24,7 +24,7 @@ spec:
     - name: template_provisioner
       provisioner: terraform # terraform, script
       source:
-        repository: main_repo # Repository name from configuration.spec.repositories
+        repository: main_repo # Remote name from solution registered repositories
         source_path: deploy/terraform
 
   # Topology (infrastructure layout)
@@ -58,7 +58,7 @@ spec:
       labels:
         role: manager
         environment: production
-      tags: [ "template", "manager" ]
+      tags: ["template", "manager"]
       # Optional: Dependencies
       depends_on: []
       # Optional: References to other resources

--- a/tests/data/configurations/configuration-standard.yaml
+++ b/tests/data/configurations/configuration-standard.yaml
@@ -19,14 +19,14 @@ spec:
   # Optional: Specify custom logging configuration
   logging:
     file: "examples/logging.development.yaml"
-  
+
   # Deployment hierarchy layers
   layering:
     - name: environment
       description: "Deployment environment (dev, staging, prod)"
       pattern: "^(dev|staging|prod)$"
       required: true
-  
+
   # Deployment configuration - defines required/optional properties for deployments
   deployment:
     additional_properties: false
@@ -43,7 +43,7 @@ spec:
         pattern: "^[a-z]{2}-[a-z]+(-[0-9]+)?$"
         required: false
         description: "Deployment region (e.g., eu-west-1, us-east-2)"
-  
+
   properties:
     # Example of arbitrary configuration properties
     deployment_manifests:
@@ -68,7 +68,7 @@ spec:
       validation:
         command: "git --version"
         min_version: "2.30.0"
-    
+
     - name: terraform
       type: terraform
       capabilities: [infrastructure]
@@ -78,7 +78,7 @@ spec:
       validation:
         command: "terraform --version"
         min_version: "1.0.0"
-    
+
     - name: bitwarden
       type: bitwarden
       capabilities: [secrets]
@@ -92,7 +92,7 @@ spec:
           api_secret: bitwarden_api_secret
       endpoints:
         address: https://vault.bitwarden.com/api
-    
+
     - name: consul
       type: consul
       capabilities: [variables, keyvalue]
@@ -101,7 +101,7 @@ spec:
       enabled: true
       endpoints:
         address: http://consul.example.local:8500
-    
+
     - name: azure-keyvault
       type: azure_keyvault
       capabilities: [secrets]
@@ -116,22 +116,22 @@ spec:
           tenant_id: azure_tenant_id
       endpoints:
         address: https://test-platform-kv.vault.azure.net/
-  
-  repositories:
+
+  remotes:
     - name: platform-iac
       type: bundled
       repository: /
       reference: main
       source_path: deploy
       description: "Platform IaC deployment artifacts"
-    
+
     - name: platform-modules
       type: gitops
       repository: https://github.com/example/platform-modules.git
       reference: main
       source_path: modules
       description: "Platform application modules"
-    
+
     - name: docker-registry
       type: container
       repository: registry.example.com/platform


### PR DESCRIPTION
# Rename configuration spec.repositories to spec.remotes

## Context and Problem Statement

Strata has two separate collections both named "repositories":

1. **`solution.json → spec.repositories`** — managed by `strata repo add`. Maps named
   source code repos to local filesystem paths. Enables `@repo/path` resolution so
   developers can work with multiple IaC/CaC/Cfg repos simultaneously, each at
   different local locations.

2. **`configuration.yaml → spec.repositories`** — hand-edited in team-shared config.
   A registry of named remote endpoints (git URLs, container registries, bundled paths)
   that the platform pulls from or pushes artifacts to.

The naming collision caused a validated bug: `workspace_service._validate_dynamic()`
checked provisioner `source.repository` references (which target solution repos) against
`configuration_model.spec.repositories` (which lists artifact backends). A repo properly
registered via `strata repo add` failed validation because the validator looked in the
wrong collection.

Beyond the bug, the shared name confuses contributors. The two concepts have different:

- **Ownership:** developer-local state vs team-shared configuration
- **Direction:** "where is my source code?" vs "where do artifacts come from / go to?"
- **Path semantics:** absolute filesystem paths vs relative deploy paths or remote URLs
- **Lifecycle:** `strata repo add` at dev setup vs defined once in config and committed

## Decision Drivers

- Pre-v1 — breaking YAML schema changes are still acceptable
- The naming collision already caused a production bug
- Contributors and AI agents repeatedly confuse the two concepts
- Solution repos cannot be merged into configuration repos (multiple repos bring
  multiple configs; solution repos are developer-local state)
- Configuration repos cannot be merged into solution repos (they define team-shared
  remote endpoints, not local checkouts)

## Rename configuration field to `spec.remotes`

Rename the configuration-side collection:

- `ConfigurationSpecModel.repositories` → `ConfigurationSpecModel.remotes`
- `RepositoryModel` class → `RemoteModel`
- `RepositoryType` enum → `RemoteType`
- `ConfigurationService.get_repositories()` → `get_remotes()`
- `ConfigurationModel.get_repo_map()` → `get_remote_map()`
- YAML field: `spec.repositories:` → `spec.remotes:`
- Solution repos stay as `repositories` (they ARE repos)

**Pro:** "Remote" is git-familiar, naturally bidirectional (fetch from, push to),
covers all three current types:
- `type: bundled` → a local remote (like `git remote add local .`)
- `type: gitops` → a git remote for manifest push/pull
- `type: container` → a container registry remote

**Pro:** Minimal conceptual distance — developers already think "remote = named URL."

**Pro:** Clear disambiguation — `repositories` = source code checkouts,
`remotes` = named endpoints.
